### PR TITLE
Deprecate OpenSSL::Digest::Digest

### DIFF
--- a/lib/s3_policy.rb
+++ b/lib/s3_policy.rb
@@ -48,7 +48,7 @@ module S3Policy
     def sign_encoded_document(encoded_policy_document, secret_key)
       Base64.strict_encode64(
         OpenSSL::HMAC.digest(
-          OpenSSL::Digest::Digest.new('sha1'),
+          OpenSSL::Digest.new('sha1'),
           secret_key,
           encoded_policy_document
         )


### PR DESCRIPTION
Hello, @STRd6 .

OpenSSL::Digest::Digest has been discouraged to use from very ancient era such as Ruby 1.8 https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
and finally was deprecated recently.